### PR TITLE
Add _sd_events to plugin handler and use plugin if instance is not set

### DIFF
--- a/src/abstracts/stream-deck-plugin-handler.ts
+++ b/src/abstracts/stream-deck-plugin-handler.ts
@@ -11,7 +11,15 @@ import {SDOnActionEvent} from "../decorators/on-action-event.decorator";
 
 export abstract class StreamDeckPluginHandler<GlobalSettings = any> extends StreamDeckHandlerBase {
 	private _globalSettings: GlobalSettings|any = 'Not available yet';
+	protected _sd_events: Function[];
 
+	constructor() {
+		super();
+		if (this._sd_events)
+			for (let event of this._sd_events)
+				event(this);
+
+	}
 	/**
 	 * Sets the action title
 	 * @param {string} title The string the title should be

--- a/src/abstracts/stream-deck-property-inspector-handler.ts
+++ b/src/abstracts/stream-deck-property-inspector-handler.ts
@@ -15,7 +15,7 @@ export abstract class StreamDeckPropertyInspectorHandler<Settings = any, GlobalS
 	private _settings: Settings|any = 'Not available yet';
 	private _globalSettings: GlobalSettings|any = 'Not available yet';
 
-	_sd_events: Function[];
+	protected _sd_events: Function[];
 
 	constructor() {
 		super();

--- a/src/decorators/on-action-event.decorator.ts
+++ b/src/decorators/on-action-event.decorator.ts
@@ -15,7 +15,7 @@ export function SDOnActionEvent(event: PossibleEventsForActionToReceive): any {
 					const eventData = JSON.parse(ev.data);
 
 					if (!eventData.action || eventData.action === actionName)
-						descriptor.value.apply(instance, [eventData]);
+						descriptor.value.apply(instance ?? plugin, [eventData]);
 				}
 			);
 		}


### PR DESCRIPTION
This seems to fix the fact that the plugin handler itself was not receiving events (at least for me). I'm not sure why it was working for you and not for me, but with debug enabled it seemed like it wasn't even trying to add the events at all.

Also, the code that looked for an instance use for apply on the descriptor was null in a lot of cases. I changed it to use the plugin – or the first argument, at any rate – if the instance is not set.