### PR TITLE
Add public constructor for plugin and PI handlers

### DIFF
--- a/src/abstracts/stream-deck-plugin-handler.ts
+++ b/src/abstracts/stream-deck-plugin-handler.ts
@@ -7,6 +7,10 @@ import {StreamDeckHandlerBase} from './stream-deck-handler-base';
  * @copyright 2021
  */
 export abstract class StreamDeckPluginHandler<GlobalSettings = any> extends StreamDeckHandlerBase<GlobalSettings> {
+    constructor() {
+        super();
+    }
+
     /**
      * Sets the action title
      * @param {string} title The string the title should be

--- a/src/abstracts/stream-deck-property-inspector-handler.ts
+++ b/src/abstracts/stream-deck-property-inspector-handler.ts
@@ -9,6 +9,10 @@ import {StreamDeckHandlerBase}           from './stream-deck-handler-base';
  * @copyright 2021
  */
 export abstract class StreamDeckPropertyInspectorHandler<Settings = any, GlobalSettings = any> extends StreamDeckHandlerBase<GlobalSettings> {
+    constructor() {
+        super();
+    }
+
     /**
      * @deprecated
      * @type {{} | Settings}


### PR DESCRIPTION
This removes the need to define a public constructor for implementations but retains the protection (?) for people extending `StreamDeckHandlerBase` without knowing what they are doing.