### PR TITLE
fix: set image crossOrigin to `anonymous` to avoid CORS restrictions

### DIFF
--- a/src/abstracts/stream-deck-plugin-handler.ts
+++ b/src/abstracts/stream-deck-plugin-handler.ts
@@ -91,6 +91,7 @@ export abstract class StreamDeckPluginHandler<
     ): Promise<string> {
         return new Promise((resolve, reject) => {
             let image = new Image();
+            image.crossOrigin = "anonymous";
 
             image.onload = () => {
                 let canvas = document.createElement('canvas');


### PR DESCRIPTION
Hey @XeroxDev!

I'm the developer of [OpenDeck](https://github.com/nekename/OpenDeck), which is an alternative reimplementation of the Elgato Stream Deck software primarily aimed at Linux users.

Instead of using a custom build of Chromium with CORS restrictions removed, which is what I presume Elgato does with their software, OpenDeck uses the default system webview.

A user was experiencing an issue with the album art not displaying on the Track Info action of the YTMD plugin and I discovered it was due to a SecurityError. Without setting the crossOrigin to anonymous in a CORS-enabled environment, the browser taints the canvas and canvas.toDataUrl cannot be used.

This PR aims to fix that by simply setting the property. Now, the YTMD plugin works properly using OpenDeck. I found another usage of `Image` in the YTMD codebase without this, so I'll open another PR there if you merge this one.

Thanks!