### PR TITLE
ci: switch npm publish to OIDC and enable provenance

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,9 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -48,6 +51,4 @@ jobs:
             git commit -m "docs: updated to newest version"
             git push || echo "Failed to push documentation updates"
           fi
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --provenance


### PR DESCRIPTION
### Motivation

- Replace usage of a long-lived `NPM_TOKEN` secret with GitHub Actions OIDC trusted publishing for improved security.
- Ensure published packages include provenance attestations to meet npm trusted-publishers guidance.
- Limit elevated secrets exposure by using workload identity instead of embedding tokens.

### Description

- Added job-level permission `id-token: write` to the `publish` job in `.github/workflows/release-please.yml` to enable OIDC authentication.
- Changed the publish step from using `NODE_AUTH_TOKEN` to run `npm publish --provenance` so npm records provenance attestations.
- Removed the environment usage of the `NPM_TOKEN` secret from the publish step.
- No other workflow steps or package metadata were modified.

### Testing

- No automated tests were executed because this is a workflow-only change.
- The change was committed and the workflow file updated at `.github/workflows/release-please.yml`.
- Verification will occur when the updated workflow runs on the next release job trigger.
- No build or unit tests were impacted by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953d6a2f4f88324addda50d1ea3bc12)