### PR TITLE
ci: isolate npm config for trusted publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,6 +29,8 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    env:
+      NPM_CONFIG_USERCONFIG: /home/runner/.npmrc.empty
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,7 +40,7 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install
+      - run: npm ci
       - run: npm run build
       - run: npm run documentation
       - name: Commit documentation updates
@@ -51,4 +53,12 @@ jobs:
             git commit -m "docs: updated to newest version"
             git push || echo "Failed to push documentation updates"
           fi
-      - run: npm publish --provenance
+      - name: Ensure no npm auth token is set
+        run: |
+          rm -f "$NPM_CONFIG_USERCONFIG"
+          echo "" > "$NPM_CONFIG_USERCONFIG"
+          npm config delete //registry.npmjs.org/:_authToken || true
+          npm config delete //registry.npmjs.org/:_auth || true
+          npm config delete //registry.npmjs.org/:always-auth || true
+      - name: Publish package with provenance
+        run: npm publish --provenance --access public


### PR DESCRIPTION
### Motivation

- Prevent the workflow from accidentally using any existing npm auth token during publish by isolating user npm config.
- Ensure the publish step uses trusted GitHub OIDC credentials rather than a stale token stored in `~/.npmrc`.
- Make installs deterministic and faster by using `npm ci` in CI.
- Ensure published packages include provenance and are published as public packages.

### Description

- Set `NPM_CONFIG_USERCONFIG` to an explicit empty file (`/home/runner/.npmrc.empty`) to force npm to read an isolated user config.
- Create an empty user config file and delete possible auth keys with `npm config delete //registry.npmjs.org/:_authToken`, `: _auth`, and `:always-auth` before publishing.
- Replace `npm install` with `npm ci` for deterministic installs.
- Publish with provenance and public access using `npm publish --provenance --access public`.

### Testing

- No automated tests were run because this change only modifies a GitHub Actions workflow file.
- Workflow syntax and file were edited and committed locally but no CI runs were executed as part of this change.
- No unit or integration tests were added or executed for this change.
- Manual verification should be performed by running the workflow in CI to confirm behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953da6589e0832480e58e8eb4a51196)